### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -19,6 +19,8 @@ env:
 
 jobs:
   devcontainer:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       CHEF_LICENSE: accept-no-persist


### PR DESCRIPTION
Potential fix for [https://github.com/sommerfeld-io/template-repository/security/code-scanning/1](https://github.com/sommerfeld-io/template-repository/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `devcontainer` job within `.github/workflows/dev-environment.yml`, setting it to the least privilege necessary. For the given steps, `contents: read` is sufficient, as the job only needs to check out code and perform read-only operations. This change should be added directly under the job name (`devcontainer:`), before `runs-on`. No other changes are necessary for this job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
